### PR TITLE
Change binding to allow editing group name

### DIFF
--- a/AspNetGroupBasedPermissions/AspNetGroupBasedPermissions.csproj
+++ b/AspNetGroupBasedPermissions/AspNetGroupBasedPermissions.csproj
@@ -17,9 +17,9 @@
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
-    <IISExpressAnonymousAuthentication />
-    <IISExpressWindowsAuthentication />
-    <IISExpressUseClassicPipelineMode />
+    <IISExpressAnonymousAuthentication>enabled</IISExpressAnonymousAuthentication>
+    <IISExpressWindowsAuthentication>enabled</IISExpressWindowsAuthentication>
+    <IISExpressUseClassicPipelineMode>false</IISExpressUseClassicPipelineMode>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>

--- a/AspNetGroupBasedPermissions/Controllers/GroupsController.cs
+++ b/AspNetGroupBasedPermissions/Controllers/GroupsController.cs
@@ -75,7 +75,7 @@ namespace AspNetGroupBasedPermissions.Controllers
         [Authorize(Roles = "Admin, CanEditGroup")]
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Edit([Bind(Include="Name")] Group group)
+        public ActionResult Edit([Bind(Include="Id,Name")] Group group)
         {
             if (ModelState.IsValid)
             {


### PR DESCRIPTION
I think this change to the binding is necessary to properly save the change of a group name in GroupsController / Edit
